### PR TITLE
Creating the Text Input Field

### DIFF
--- a/components/textInputField/TextInputField.js
+++ b/components/textInputField/TextInputField.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { TextInput, TextLabel } from './TextInputField.style';
+
+export default function TextInputField({ label, onChange }) {
+  return (
+    <>
+      <TextLabel>{label}</TextLabel>
+      <TextInput type="text" onChange={(e) => onChange(e.target.value)} />
+    </>
+  );
+}

--- a/components/textInputField/TextInputField.js
+++ b/components/textInputField/TextInputField.js
@@ -1,11 +1,15 @@
 import React from 'react';
 import { TextInput, TextLabel } from './TextInputField.style';
 
-export default function TextInputField({ label, onChange }) {
+export default function TextInputField({ id, label, onChange }) {
   return (
     <>
-      <TextLabel>{label}</TextLabel>
-      <TextInput type="text" onChange={(e) => onChange(e.target.value)} />
+      <TextLabel for={id}>{label}</TextLabel>
+      <TextInput
+        type="text"
+        name={id}
+        onChange={(e) => onChange(e.target.value)}
+      />
     </>
   );
 }

--- a/components/textInputField/TextInputField.style.js
+++ b/components/textInputField/TextInputField.style.js
@@ -14,7 +14,7 @@ const TextInput = styled(P).attrs({
   display: block;
   border: none;
   border-bottom: 1px solid ${colors.BROWN};
-  width: clamp(300px, 55vw, 500px);
+  width: clamp(16em, 60vw, 26em);
 
   &:focus {
     outline: none;

--- a/components/textInputField/TextInputField.style.js
+++ b/components/textInputField/TextInputField.style.js
@@ -1,0 +1,24 @@
+import styled from 'styled-components';
+import { P } from '../../style/typography';
+import { colors } from '../../style/colors';
+
+const TextLabel = styled(P)`
+  color: ${colors.BROWN};
+  display: block;
+  margin: 0;
+`;
+
+const TextInput = styled(P).attrs({
+  as: 'input',
+})`
+  display: block;
+  border: none;
+  border-bottom: 1px solid ${colors.BROWN};
+  width: clamp(300px, 55vw, 500px);
+
+  &:focus {
+    outline: none;
+  }
+`;
+
+export { TextLabel, TextInput };


### PR DESCRIPTION
Here is what it looks like in action:
![image](https://user-images.githubusercontent.com/49954595/113645743-738dee00-9655-11eb-9f71-862dd000c749.png)

Can be used by importing the TextInputField and passing in the `label` and `onChange`.  Where the label is the wanted label for the input and onChange is the onChange method used to keep track of the state of the input.

Example:
`<TextInputField label={“First Name”} onChange={setName} />`