### PR TITLE
Bug: Font-sizing 

### DIFF
--- a/style/typography.js
+++ b/style/typography.js
@@ -6,10 +6,10 @@ const fonts = {
 
 
 const fontSizes = {
-    h1: `calc(40px + (90 - 40) * ((100vw - 320px) / (1440 - 320)))`,
-    h2: `calc(30px + (50 - 30) * ((100vw - 320px) / (1440 - 320)))`,
-    h3: `calc(22px + (20 - 22) * ((100vw - 320px) / (1440 - 320)))`,
-    p: `calc(14px + (22 - 14) * ((100vw - 320px) / (1440 - 320)))`,
+    h1: `clamp(2.5em, 8vw, 8em)`,
+    h2: `clamp(1.8em, 5vw, 6em)`,
+    h3: `clamp(1em, 2.5vw, 3em)`,
+    p: `clamp(.6em, 1.5vw, 2em)`,
 }
 
 const fontStyles = {


### PR DESCRIPTION
- Changed responsive font sizing from using calc to clamp to fix issue where fonts weren't increasing / decreasing with screen size. 
- To use clamp: pass in the min size, how it is expected to increase, and max size. 
- Example: clamp(1em, 5vw, 3em) 

![image](https://user-images.githubusercontent.com/59738880/112506886-8c98c400-8d64-11eb-9359-31b477dd695a.png)
![image](https://user-images.githubusercontent.com/59738880/112506930-97535900-8d64-11eb-957d-e95cabb12959.png)
![image](https://user-images.githubusercontent.com/59738880/112506955-9f12fd80-8d64-11eb-8748-1caf63be63b2.png)
