### PR TITLE
Bug Fix: Safari Clamp Not Responsive

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -13,4 +13,5 @@ a {
 
 * {
   box-sizing: border-box;
+  min-height: 0vw;
 }


### PR DESCRIPTION
Issue: When deployed in Safari and changing the window width the text was not responsively changing size. This is because Safari calculates clamp incorrectly. **Note: Clamp calculation works on the other browsers **

Solution: Adding `min-height: 0vw` to the global.css


Helpful Link for [Solution](https://stackoverflow.com/questions/63965489/safari-14-min-max-clamp-not-working-with-vw-and-px-values)