### PR TITLE
Reusable component: H1Styled

### DIFF
--- a/components/H1Styled/H1Styled.js
+++ b/components/H1Styled/H1Styled.js
@@ -1,0 +1,13 @@
+import { getString } from '../../lib/richText';
+import { H1Container, H1Italicized, H1Regular } from './H1Styled.styles';
+
+export default function H1Styled({ regular, italicized }) {
+  return (
+    <H1Container>
+      <H1Regular>{getString(regular)}</H1Regular>
+      <H1Italicized>
+        <i>{getString(italicized)}</i>
+      </H1Italicized>
+    </H1Container>
+  );
+}

--- a/components/H1Styled/H1Styled.styles.js
+++ b/components/H1Styled/H1Styled.styles.js
@@ -1,0 +1,40 @@
+import { H1 } from '../../style/typography';
+import styled from 'styled-components';
+import { min } from '../../lib/responsive';
+
+const H1Container = styled.div`
+  white-space: nowrap;
+  @media ${min.mobile} {
+    margin: 25em 0 5em 7.5em;
+  }
+  @media ${min.tablet} {
+    margin: 20.5em 0 4em 8em;
+  }
+  @media ${min.desktop} {
+    margin: 4em 0 2em 5.9em;
+  }
+`;
+
+const H1Regular = styled(H1)`
+  margin: 0 auto;
+`;
+
+const H1Italicized = styled(H1)`
+  @media ${min.mobile} {
+    padding: 0;
+    margin: 0 0 0 0.65em;
+    line-height: 0.3em;
+  }
+  @media ${min.tablet} {
+    padding: 0;
+    margin: 0 0 0 0.55em;
+    line-height: 0.3em;
+  }
+  @media ${min.desktop} {
+    padding: 0;
+    margin: 0 0 0 0.76em;
+    line-height: 0.43em;
+  }
+`;
+
+export { H1Container, H1Regular, H1Italicized };

--- a/components/H1Styled/H1Styled.styles.js
+++ b/components/H1Styled/H1Styled.styles.js
@@ -21,17 +21,14 @@ const H1Regular = styled(H1)`
 
 const H1Italicized = styled(H1)`
   @media ${min.mobile} {
-    padding: 0;
     margin: 0 0 0 0.65em;
     line-height: 0.3em;
   }
   @media ${min.tablet} {
-    padding: 0;
     margin: 0 0 0 0.55em;
     line-height: 0.3em;
   }
   @media ${min.desktop} {
-    padding: 0;
     margin: 0 0 0 0.76em;
     line-height: 0.43em;
   }

--- a/pages/archive/[page].js
+++ b/pages/archive/[page].js
@@ -8,8 +8,9 @@ import {
 import Navigation from '../../components/navigation/Navigation';
 import Footer from '../../components/footer/Footer';
 import PageLink from '../../components/pageLink/PageLink';
-import { H1, H2, P } from '../../style/typography';
+import { H2, P } from '../../style/typography';
 import { getString } from '../../lib/richText';
+import H1Styled from '../../components/H1Styled/H1Styled';
 
 export default function StoryArchive({
   storyArchivePageData,
@@ -27,10 +28,7 @@ export default function StoryArchive({
   return (
     <>
       <Navigation navigationData={navigationData} />
-      <H1>{getString(archiveTitleRegular)}</H1>
-      <H1>
-        <i>{getString(archiveTitleItalic)}</i>
-      </H1>
+      <H1Styled regular={archiveTitleRegular} italicized={archiveTitleItalic} />
       <P>{getString(archiveDescription)}</P>
       <img src={archiveHeaderImage.url} alt={archiveHeaderImage.alt} />
       {stories.map((story, index) => {

--- a/pages/contact.js
+++ b/pages/contact.js
@@ -2,8 +2,9 @@ import { getContactPage, getNavigation, getFooter } from '../lib/api';
 import Navigation from '../components/navigation/Navigation';
 import Footer from '../components/footer/Footer';
 import ContactConfirmation from '../components/contactConfirmation/ContactConfirmation';
-import { H1, P } from '../style/typography';
+import { P } from '../style/typography';
 import { getString } from '../lib/richText';
+import H1Styled from '../components/H1Styled/H1Styled';
 
 export default function ContactPage({
   contactPageData,
@@ -34,10 +35,10 @@ export default function ContactPage({
   return (
     <>
       <Navigation navigationData={navigationData} />
-      <H1>{getString(contactPageTitleRegular)}</H1>
-      <H1>
-        <i>{getString(contactPageTitleItalic)}</i>
-      </H1>
+      <H1Styled
+        regular={contactPageTitleRegular}
+        italicized={contactPageTitleItalic}
+      />
       <P>{getString(contactPageDescription)}</P>
       <img src={contactImageTop.url} alt={contactImageTop.alt} />
       <img src={contactImageBottom.url} alt={contactImageBottom.alt} />

--- a/pages/index.js
+++ b/pages/index.js
@@ -8,8 +8,9 @@ import Navigation from '../components/navigation/Navigation';
 import Footer from '../components/footer/Footer';
 import FeaturedStoryPreview from '../components/featuredStoryPreview/FeaturedStoryPreview';
 import NewsletterConfirmation from '../components/newsletterConfirmation/NewsletterConfirmation';
-import { H1, H2, P } from '../style/typography';
+import { H2, P } from '../style/typography';
 import { getString } from '../lib/richText';
+import H1Styled from '../components/H1Styled/H1Styled';
 
 export default function HomePage({
   homePageData,
@@ -40,9 +41,7 @@ export default function HomePage({
   return (
     <>
       <Navigation navigationData={navigationData} />
-      <H1>
-        <i>{getString(homePageTitle)}</i>
-      </H1>
+      <H1Styled regular={homePageTitle} italicized={undefined} />
       <H2>{getString(featuredStoriesTitle)}</H2>
       {featuredStoriesData.map((item) => {
         return <FeaturedStoryPreview key={item.uid} featuredStoryData={item} />;

--- a/style/typography.js
+++ b/style/typography.js
@@ -1,12 +1,12 @@
 import styled from 'styled-components';
 import { min } from '../lib/responsive';
+import { colors } from './colors';
 const fonts = {
   swearDisplay: 'swear-display, serif',
   poppins: 'poppins, sans-serif',
 };
 
 const fontSizes = {
-  h1: 'clamp(11em, 25vw, 14em)',
   h2: 'clamp(5em, 10vw, 8em)',
   h3: 'clamp(3em, 5vw, 4em)',
 };
@@ -22,9 +22,16 @@ const fontWeights = {
 };
 
 const H1 = styled.h1`
-  font-size: ${fontSizes.h1};
   font-family: ${fonts.swearDisplay};
   font-weight: ${fontWeights.medium};
+  color: ${colors.BURNTORANGE};
+  font-size: 16em;
+  @media ${min.tablet} {
+    font-size: 13em;
+  }
+  @media ${min.desktop} {
+    font-size: 10em;
+  }
 `;
 
 const H2 = styled.h2`
@@ -43,9 +50,12 @@ const H3 = styled.h3`
 const P = styled.p`
   font-family: ${fonts.poppins};
   font-weight: ${fontWeights.regular};
-  font-size: 2em;
+  font-size: 2.2em;
   @media ${min.tablet} {
-    font-size: 1.2em;
+    font-size: 1.6em;
+  }
+  @media ${min.desktop} {
+    font-size: 1em;
   }
 `;
 


### PR DESCRIPTION
- H1Styled.js: component to take in regular and italicized title parts and renders the header 
- Responsive styling for mobile, tablet and desktop implemented in H1Styled.styles.js
- Added in typography.js changes from configuration/reduced-font-sizing PR b/c necessary to correctly implement spacing 
- Top spacing implemented without navigation into consideration 
       -  I assumed the navigation would likely be fixed / absolute and not push down the header 
- *Note* I based the spacing and everything off of the contact page so minor tweaks may be needed for other pages
![image](https://user-images.githubusercontent.com/59738880/113643351-222f3000-9650-11eb-9525-b6406d2e7398.png)
![image](https://user-images.githubusercontent.com/59738880/113643401-3f63fe80-9650-11eb-979c-1d437213dfe3.png)
![image](https://user-images.githubusercontent.com/59738880/113643386-383cf080-9650-11eb-8de3-91f1466a18f3.png)
