### PR TITLE
Updated _document.js to load styled-components

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,5 +1,7 @@
 import Document, { Html, Head, Main, NextScript } from 'next/document';
+import { ServerStyleSheet } from 'styled-components';
 import { colors } from '../style/colors';
+
 export default class MyDocument extends Document {
   render() {
     return (
@@ -13,5 +15,31 @@ export default class MyDocument extends Document {
         </body>
       </Html>
     );
+  }
+
+  static async getInitialProps(ctx) {
+    const sheet = new ServerStyleSheet();
+    const originalRenderPage = ctx.renderPage;
+
+    try {
+      ctx.renderPage = () =>
+        originalRenderPage({
+          enhanceApp: (App) => (props) =>
+            sheet.collectStyles(<App {...props} />),
+        });
+
+      const initialProps = await Document.getInitialProps(ctx);
+      return {
+        ...initialProps,
+        styles: (
+          <>
+            {initialProps.styles}
+            {sheet.getStyleElement()}
+          </>
+        ),
+      };
+    } finally {
+      sheet.seal();
+    }
   }
 }


### PR DESCRIPTION
Solve the flash of unstyled content

Code from:
https://github.com/vercel/next.js/blob/canary/examples/with-styled-components/pages/_document.js