### PR TITLE
Nitpick: Designer edits 1

### DIFF
--- a/components/arch-modal/ArchModal.styles.js
+++ b/components/arch-modal/ArchModal.styles.js
@@ -112,8 +112,8 @@ export const ArchModalCloseButton = styled.button`
 
   @media ${max.tabletSm} {
     top: -10px;
-    width: 40px;
-    height: 40px;
+    width: 50px;
+    height: 50px;
   }
 `;
 

--- a/components/confirmation-popup/ConfirmationPopup.styles.js
+++ b/components/confirmation-popup/ConfirmationPopup.styles.js
@@ -129,6 +129,9 @@ const CloseIcon = styled.img`
   @media ${min.desktop} {
     width: 1.3em;
   }
+  &:hover {
+    cursor: pointer;
+  }
 `;
 
 export {

--- a/components/contact-page/contact-form/ContactForm.js
+++ b/components/contact-page/contact-form/ContactForm.js
@@ -1,6 +1,7 @@
+import { colors } from '../../../style/colors';
 import TextInputField from '../../text-input-field/TextInputField';
 import TextInputBox from '../../text-input-box/TextInputBox';
-import SquareButton from '../../square-button/SquareButton';
+import { SubmitButton } from '../../home-page/newsletter-sign-up/NewsletterSignUp.styles';
 import {
   ContactFormContainer,
   InputBoxWrapper,
@@ -72,9 +73,10 @@ export default function ContactForm({ togglePopup }) {
           />
         </InputBoxWrapper>
         <ButtonWrapper>
-          <SquareButton
+          <SubmitButton
             aria-label="Submission Button"
-            buttonText="SUBMIT"
+            color={colors.WHITE}
+            type="submit"
             onClick={() => {
               if (submitRequest()) {
                 document.body.style.overflow = 'hidden';
@@ -83,7 +85,9 @@ export default function ContactForm({ togglePopup }) {
                 togglePopup();
               }
             }}
-          />
+          >
+            SUBMIT
+          </SubmitButton>
         </ButtonWrapper>
       </ContactFormContainer>
     </>

--- a/components/home-page/current-featured-story/CurrentFeaturedStory.styles.js
+++ b/components/home-page/current-featured-story/CurrentFeaturedStory.styles.js
@@ -59,6 +59,7 @@ export const CurrentFeaturedStoryButton = styled(HoverAnimationButton)`
   background-size: 85%;
   background-position: left center;
   border: none;
+  padding: 0;
 
   &:hover {
     animation: ${LeftRightAnimation} 0.8s forwards;

--- a/components/home-page/current-featured-story/CurrentFeaturedStory.styles.js
+++ b/components/home-page/current-featured-story/CurrentFeaturedStory.styles.js
@@ -33,20 +33,20 @@ export const CurrentFeaturedStoryImage = styled.img`
 
 export const CurrentFeaturedStoryTextWrapper = styled.div`
   width: calc(100% - min(400px, 50%));
-  margin-left: 8%;
+  margin: auto 0 auto 8%;
   z-index: 2;
 `;
 
 export const CurrentFeaturedStoryH1 = styled(H1)`
   color: ${colors.BLACK};
   font-size: clamp(2.5em, 3.5vw, 3.5em);
-  margin-left: -260px;
-  margin-bottom: 0.5em;
+  margin: 0 auto 0 -260px;
+  overflow: hidden;
   text-overflow: ellipsis;
-  white-space: nowrap;
+  height: 2.6em;
 
   @media ${max.tablet} {
-    margin-bottom: 10px;
+    margin-top: 15px;
     margin-left: -150px;
   }
 `;

--- a/components/navigation/Navigation.js
+++ b/components/navigation/Navigation.js
@@ -23,6 +23,27 @@ export default function Navigation({ navigationData }) {
     `(max-width: ${breakpointsObj.tabletLg}px)`,
   );
 
+  const currentPage = () => {
+    if (typeof window === 'object') {
+      const splitUrl = window.location.href.split('/');
+      return splitUrl.includes('archive')
+        ? 'archive'
+        : splitUrl[splitUrl.length - 1] || 'home';
+    } else {
+      return '';
+    }
+  };
+
+  const getNavigationLinks = () => {
+    return navigationLinks.map((navigationLink, index) => (
+      <NavigationLink
+        key={index}
+        navigationLink={navigationLink}
+        onPage={currentPage() == navigationLink.link.uid}
+      />
+    ));
+  };
+
   return (
     <>
       <NavigationWrapper>
@@ -41,12 +62,7 @@ export default function Navigation({ navigationData }) {
             {isHamburgerOpen && (
               <HamburgerMenu>
                 <HamburgerMenuContent>
-                  {navigationLinks.map((navigationLink, index) => (
-                    <NavigationLink
-                      key={index}
-                      navigationLink={navigationLink}
-                    />
-                  ))}
+                  {getNavigationLinks()}
                 </HamburgerMenuContent>
                 <CloseXImage
                   src={icons.CLOSE_ICON}
@@ -61,9 +77,7 @@ export default function Navigation({ navigationData }) {
           </>
         ) : (
           <NavigationLinksWrapper>
-            {navigationLinks.map((navigationLink, index) => (
-              <NavigationLink key={index} navigationLink={navigationLink} />
-            ))}
+            {getNavigationLinks()}
           </NavigationLinksWrapper>
         )}
       </NavigationWrapper>
@@ -71,13 +85,13 @@ export default function Navigation({ navigationData }) {
   );
 }
 
-function NavigationLink({ navigationLink }) {
+function NavigationLink({ navigationLink, onPage }) {
   const { link_name: linkName, link } = navigationLink;
 
   switch (link.link_type) {
     case 'Document':
       return (
-        <LinkWrapper>
+        <LinkWrapper onPage={onPage}>
           <PageLink href={link.uid === 'home' ? '/' : `/${link.uid}`}>
             {getString(linkName)}
           </PageLink>

--- a/components/navigation/Navigation.styles.js
+++ b/components/navigation/Navigation.styles.js
@@ -64,18 +64,26 @@ export const LinkWrapper = styled(HoverAnimationButton)`
   font-size: 1em;
   font-family: ${fonts.poppins};
   color: ${colors.BROWN};
-  font-weight: ${fontWeights.normal};
+  font-weight: ${(props) =>
+    props.onPage ? fontWeights.medium : fontWeights.normal};
   text-transform: uppercase;
   letter-spacing: 0.13em;
 
   @media ${max.tabletLg} {
     margin-bottom: 3em;
     width: min(18em, 100%);
+    font-weight: ${fontWeights.normal};
     &:hover {
       background: url(${icons.LONG_UNFILLED_SPARK_ARROW_HORIZONTAL}) no-repeat;
       background-position: right center;
       background-size: contain;
     }
+    background: ${(props) =>
+      props.onPage
+        ? `url(${icons.LONG_UNFILLED_SPARK_ARROW_HORIZONTAL}) no-repeat`
+        : `inherit`};
+    background-position: center center;
+    background-size: contain;
   }
 `;
 

--- a/components/story-archive-page/archive-pagination/ArchivePagination.js
+++ b/components/story-archive-page/archive-pagination/ArchivePagination.js
@@ -11,7 +11,7 @@ export default function ArchivePagination({ paginationData, sortType }) {
 
   return (
     <PaginationWrapper>
-      <PageLink href={ARCHIVE + (page - 1)}>
+      <PageLink href={ARCHIVE + (page - 1) + '#archive'}>
         <ArchiveArrow
           src={icons.FILLED_SHORT_ARROW}
           disabled={prevDisabled}
@@ -22,7 +22,7 @@ export default function ArchivePagination({ paginationData, sortType }) {
       <P>
         {page} / {totalPages}
       </P>
-      <PageLink href={ARCHIVE + (page + 1)}>
+      <PageLink href={ARCHIVE + (page + 1) + '#archive'}>
         <ArchiveArrow
           src={icons.FILLED_SHORT_ARROW}
           disabled={nextDisabled}

--- a/components/story-archive-page/archive-sorting/ArchiveSorting.js
+++ b/components/story-archive-page/archive-sorting/ArchiveSorting.js
@@ -10,7 +10,7 @@ const ALPHA = 'alpha';
 const DATE = 'date';
 
 const sortUrl = (selectedSortType) =>
-  '/archive/' + selectedSortType.toLowerCase() + '/' + 1;
+  '/archive/' + selectedSortType.toLowerCase() + '/' + 1 + '#archive';
 
 export default function ArchiveSorting({ sortType, order }) {
   const label = order == DATE ? 'MOST RECENT' : 'A - Z';

--- a/components/story-archive-page/archive-story-preview/ArchiveStoryPreview.style.js
+++ b/components/story-archive-page/archive-story-preview/ArchiveStoryPreview.style.js
@@ -62,6 +62,11 @@ const StoryPreviewTitle = styled(H3)`
   font-size: clamp(1.5em, 6vw, 2em);
   bottom: 1vh;
   padding: 0 10%;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
 
   @media only screen and ${max.tabletSm} {
     bottom: 0vh;

--- a/components/text-input-box/TextInputBox.styles.js
+++ b/components/text-input-box/TextInputBox.styles.js
@@ -45,6 +45,8 @@ const InputBox = styled.textarea`
   font-weight: ${fontWeights.normal};
   font-size: 1em;
   padding: 0.5em;
+  -webkit-appearance: none;
+  border-radius: 0px;
 `;
 
 export { InputBox, InputBoxLabel, StarLabelContainer, RedStar, ErrorText };


### PR DESCRIPTION
This PR contains fixes to some of the designer edits from the [excel](https://docs.google.com/spreadsheets/d/1-uzCCu48XLRHw-uEnCEO1hyksYOItZXokiCBcxajltI/edit?pli=1#gid=0).

To test double check:
- Home featured story text centered and left aligned
- Archive sorting and pagination should not go back to the top
- Privacy policy larger close button on mobile
- Contact page no rounded corners and inner shadow on mobile
- Navigation current page bold/hover state
- Contact page use same submit button as home page
- Archive story handling long title
- Confirmation popup cursor for close button