### PR TITLE
Update: Signature pad height

### DIFF
--- a/components/story-inquiry-page/story-inquiry-form/author-signature/AuthorSignature.js
+++ b/components/story-inquiry-page/story-inquiry-form/author-signature/AuthorSignature.js
@@ -51,7 +51,7 @@ export default function AuthorSignature({
                 <SignatureCanvasWrapper id="signature canvas wrapper" ref={ref}>
                     <SignatureCanvas
                         penColor="white"
-                        canvasProps={{ width: canvasWidth, height: 60 }}
+                        canvasProps={{ width: canvasWidth, height: canvasWidth / 2.6 }}
                         ref={(ref) => setSigPad(ref)}
                         minWidth={1.5}
                         maxWidth={1.5}


### PR DESCRIPTION
Updated signature pad height to to width ratio to be 1 : 2.6 (same as ratio on Prismic). 